### PR TITLE
[for reference] support Windows by using scapy

### DIFF
--- a/hpavcli.py
+++ b/hpavcli.py
@@ -2,14 +2,13 @@
 
 import os
 import sys
-import platform
 import argparse
+
+from scapy.all import *
 
 
 def get_default_interface() -> str:
-    gw = netifaces.gateways().get('default')
-    gw_if = gw[netifaces.AF_INET][1]
-    return gw_if
+    return conf.iface.name
 
 
 def parse_args() -> argparse.Namespace:
@@ -27,10 +26,6 @@ def parse_args() -> argparse.Namespace:
 
 
 def main(in_args: argparse.Namespace):
-    if platform.system() != "Linux":
-        print("Sorry, this code needs to be run on Linux.")
-        sys.exit(-1)
-
     if in_args.interface:
         interface_list = in_args.interface.split(',')
     else:
@@ -39,7 +34,7 @@ def main(in_args: argparse.Namespace):
     interfaces = list()
     for iface in interface_list:
         try:
-            interfaces.append(PowerlineInterface(iface, verbose=in_args.verbose))
+            interfaces.append(PowerlineInterface(ifaces.dev_from_name(iface), verbose=in_args.verbose))
         except (ValueError, PermissionError) as exc:
             print(f"Error creating PowerlineInterface for {iface}: {exc}")
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 netifaces==0.11.0
+scapy==2.5.0
 pytest==7.1.2
 pytest-cov==3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 netifaces==0.11.0
+scapy==2.5.0


### PR DESCRIPTION
Hi, and thanks for the nice tool!

I made it use scapy (https://scapy.readthedocs.io/en/latest/, https://scapy.net/) to be able to use it on Windows. Scapy uses the pcap interfaces on Windows and overcomes the limitations imposed by the standard Python `socket`.

View this PR mostly "for reference" only, if you or anyone else is interested in further development, as it should not be considered complete.
Current state:
- no tests implemented for now
- not tested on Linux as I sadly have no Linux hardware with me
- increased timeout to 0.5 for slow devices and networks
- readme would need update